### PR TITLE
переменная VITE_BASE_API_URL

### DIFF
--- a/client/.env
+++ b/client/.env
@@ -1,0 +1,1 @@
+VITE_BASE_API_URL=http://localhost:3002/

--- a/client/src/shared/const/api/baseApiUrl.ts
+++ b/client/src/shared/const/api/baseApiUrl.ts
@@ -1,1 +1,1 @@
-export const BASE_API_URL = 'http://localhost:3002/'
+export const BASE_API_URL = import.meta.env.VITE_BASE_API_URL


### PR DESCRIPTION
# переменная базового апи урла достаётся из файла .env `VITE_BASE_API_URL`