### PR TITLE
FE: ПРАВИТ параметр ссылки клиента

### DIFF
--- a/client/src/entities/Client/ui/Client.tsx
+++ b/client/src/entities/Client/ui/Client.tsx
@@ -44,11 +44,11 @@ export const Client = ({ client }: ClientProps) => {
           {mobilePhone}
         </a>
       </div>
-      <div className={clx.moreInfo}>
-        <Link to={`${ROUTER_PATH.USERS} + ":" + ${id}`}>
-          <Button size={ButtonSize.S}>Подробнее &#62;</Button>
-        </Link>
-      </div>
+      {/* <div className={clx.moreInfo}> */}
+      <Link to={`${ROUTER_PATH.USERS}/${id}`}>
+        <Button size={ButtonSize.S}>Подробнее &#62;</Button>
+      </Link>
+      {/* </div> */}
     </li>
   )
 }


### PR DESCRIPTION
Проблема была такая, что нажав на кнопку подробно в карточке клиента перебрасывало на страницу с непонятным параметром. 

Теперь всё 👌, получаем /users/1 к примеру